### PR TITLE
Fix h5 and h6 weird sizing

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -861,6 +861,28 @@ body:not(.encore-disable-typography-spacing) .markdown-source-view.mod-cm6 .cm-l
   padding-bottom: 0.5em;
 }
 
+body {
+  --h5-size: 0.75rem;
+  --h5-line-height: 1.5;
+  --h5-weight: 600;
+}
+
+body:not(.encore-disable-typography-spacing) .markdown-source-view.mod-cm6 .cm-line.HyperMD-header.HyperMD-header-5 {
+  padding-top: 0.8em;
+  padding-bottom: 0.5em;
+}
+
+body {
+  --h6-size: 0.5rem;
+  --h6-line-height: 1.5;
+  --h6-weight: 600;
+}
+
+body:not(.encore-disable-typography-spacing) .markdown-source-view.mod-cm6 .cm-line.HyperMD-header.HyperMD-header-6 {
+  padding-top: 0.8em;
+  padding-bottom: 0.5em;
+}
+
 .markdown-source-view .cm-sizer .HyperMD-codeblock-begin-bg {
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;


### PR DESCRIPTION
Fixes #16 

I've added a few code snippets to act as a base to fix the issue #16.
There are still some values to tweak, since I didn't see any significant pattern for the `--line-height` variable to change it properly.

_PD: It now looks a bit funky, but I've only added reference values for the devs to tweak it properly. Hope this can be useful :smile: :_
![image](https://github.com/Carbonateb/obsidian-encore-theme/assets/87392968/917c9e8a-9b3b-436f-850e-7cd0cc4a0f58)
